### PR TITLE
Add keyboard navigation for other comics

### DIFF
--- a/hscompanion.js
+++ b/hscompanion.js
@@ -83,22 +83,24 @@ function requestCommentary() {
 document.onkeydown = function(e) {
     switch (e.keyCode) {
     	case 17: //either ctrl key
-    		if(e.location == 2){ //restricts key to right ctrl
-    			if(document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
+    		if (e.location == 2){ //restricts key to right ctrl
+    			if (document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
             		document.getElementsByClassName("o_chat-log-btn")[0].click();
         		}
         	}
     		break;
         case 37: //left arrow
         	//If you are not playing a walkaround, change page
-        	if(document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
-            	document.getElementsByClassName("o_game-nav-item")[1].lastElementChild.click();
+        	if (document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
+				document.getElementsByClassName("disp-ib")[0].lastElementChild.click(); // `disp-ib` is SBaHJ's special forward / backward nav box
+				document.getElementsByClassName("o_game-nav-item")[1].lastElementChild.click();
         	}
             break;
         case 39: //right arrow
-        	if(document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
-            	document.getElementsByClassName("o_story-nav type-hs-copy line-tight pad-x-0 pad-x-lg--md")[0].lastElementChild.children[1].click();  // This also handles the Epilogues if we remove the last class `mar-b-lg` (Epilogues use `pad-b`lg`).
-            }
+        	if (document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
+				document.getElementsByClassName("disp-ib")[1].firstElementChild.click();
+				document.getElementsByClassName("o_story-nav type-hs-copy line-tight pad-x-0 pad-x-lg--md")[0].lastElementChild.children[1].click();  // This also handles the Epilogues if we remove the last class `mar-b-lg` (Epilogues use `pad-b`lg`).
+			}
             break;
     }
 };

--- a/hscompanion.js
+++ b/hscompanion.js
@@ -98,7 +98,9 @@ document.onkeydown = function(e) {
             break;
         case 39: //right arrow
         	if (document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
-				document.getElementsByClassName("disp-ib")[1].firstElementChild.click();
+				if (window.location.hostname != "homestuck2.com") { // site-specific workaround - for some reason, `click()`ing both elements doesn't work on Homestuck^2
+					document.getElementsByClassName("disp-ib")[1].firstElementChild.click();
+				}
 				document.getElementsByClassName("o_story-nav type-hs-copy line-tight pad-x-0 pad-x-lg--md")[0].lastElementChild.children[1].click();  // This also handles the Epilogues if we remove the last class `mar-b-lg` (Epilogues use `pad-b`lg`).
 			}
             break;

--- a/hscompanion.js
+++ b/hscompanion.js
@@ -97,7 +97,7 @@ document.onkeydown = function(e) {
             break;
         case 39: //right arrow
         	if(document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
-            	document.getElementsByClassName("o_story-nav type-hs-copy line-tight pad-x-0 pad-x-lg--md mar-b-lg")[0].lastElementChild.children[1].click();
+            	document.getElementsByClassName("o_story-nav type-hs-copy line-tight pad-x-0 pad-x-lg--md")[0].lastElementChild.children[1].click();  // This also handles the Epilogues if we remove the last class `mar-b-lg` (Epilogues use `pad-b`lg`).
             }
             break;
     }

--- a/hscompanion.js
+++ b/hscompanion.js
@@ -8,7 +8,7 @@ var adv = url.pop();
 
 if (page === "story" || page === "problem-sleuth"){
 	adv = page;
-	page = 1; 
+	page = 1;
 }
 
 //console.log(adv + " " + page); //I use this for debugging, don't judge
@@ -20,60 +20,62 @@ hussiecomment.then(result => {
     requestCommentary();
 });
 
-//Time to request the commentary from the API 
+//Time to request the commentary from the API
 
 function requestCommentary() {
-	fetch('https://recordcrash.com:3141/' + adv + '/' + page)
-		.then(data => data.json())
-		.then(datajson => {
-			if ((datajson[0].commentary != null)){ //If there's actually commentary for that page, we try to create the container
-				//We create the div we're going to embed in the page based on homestuck.com standards
+	if (window.location.hostname != "homestuck2.com") { // Only load commentary on the Homestuck proper domain - prevents issues with Homestuck^2
+		fetch('https://recordcrash.com:3141/' + adv + '/' + page)
+			.then(data => data.json())
+			.then(datajson => {
+				if ((datajson[0].commentary != null)){ //If there's actually commentary for that page, we try to create the container
+					//We create the div we're going to embed in the page based on homestuck.com standards
 
-				var son = document.createElement("div");
-        son.id = "commentary";
-				son.className = "row bg-hs-gray bg-light-gray--md pad-b-md pad-b-lg--md pos-r";
-				var sonsson = document.createElement("div");
-				sonsson.className = "mar-x-auto disp-bl bg-hs-gray pad-t-lg";
-				sonsson.style = "max-width:650px;";
-				var commentary = document.createElement("p");
-				commentary.className = "o-story_text type-rg type-hs-small--md type-center line-caption line-copy--md pad-x-0 pad-x-lg--md pad-b-lg";
-        commentary.style = "white-space:pre-line;";
+					var son = document.createElement("div");
+					son.id = "commentary";
+					son.className = "row bg-hs-gray bg-light-gray--md pad-b-md pad-b-lg--md pos-r";
+					var sonsson = document.createElement("div");
+					sonsson.className = "mar-x-auto disp-bl bg-hs-gray pad-t-lg";
+					sonsson.style = "max-width:650px;";
+					var commentary = document.createElement("p");
+					commentary.className = "o-story_text type-rg type-hs-small--md type-center line-caption line-copy--md pad-x-0 pad-x-lg--md pad-b-lg";
+					commentary.style = "white-space:pre-line;";
 
-				//We add the commentary to it (Note to self: look into just doing a secure innerHTML so we can add images in the future)
-				commentary.textContent = datajson[0].commentary;
+					//We add the commentary to it (Note to self: look into just doing a secure innerHTML so we can add images in the future)
+					commentary.textContent = datajson[0].commentary;
 
-				//And now we add the commentary container to the div, the div to the other div, etc
-				sonsson.appendChild(commentary);
-				son.appendChild(sonsson);
-				document.getElementsByClassName("pos-r")[0].appendChild(son);
-			}
+					//And now we add the commentary container to the div, the div to the other div, etc
+					sonsson.appendChild(commentary);
+					son.appendChild(sonsson);
+					document.getElementsByClassName("pos-r")[0].appendChild(son);
+				}
 
-			if ((datajson[0].notes != null)){ //If there's actually notes for that page, we try to create the container
-				//We create the div we're going to embed in the page based on homestuck.com standards
+				if ((datajson[0].notes != null)){ //If there's actually notes for that page, we try to create the container
+					//We create the div we're going to embed in the page based on homestuck.com standards
 
-				var son = document.createElement("div");
-        son.id = "notes";
-				son.className = "row bg-hs-gray bg-light-gray--md pad-b-md pad-b-lg--md pos-r";
-				var sonsson = document.createElement("div");
-				sonsson.className = "mar-x-auto disp-bl bg-hs-gray pad-t-lg";
-				sonsson.style = "max-width:650px;";
-				var notes = document.createElement("p");
-				notes.className = "o-story_text type-rg type-hs-small--md type-center line-caption line-copy--md pad-x-0 pad-x-lg--md pad-b-lg";
-        notes.style = "white-space:pre-line;";
+					var son = document.createElement("div");
+					son.id = "notes";
+					son.className = "row bg-hs-gray bg-light-gray--md pad-b-md pad-b-lg--md pos-r";
+					var sonsson = document.createElement("div");
+					sonsson.className = "mar-x-auto disp-bl bg-hs-gray pad-t-lg";
+					sonsson.style = "max-width:650px;";
+					var notes = document.createElement("p");
+					notes.className = "o-story_text type-rg type-hs-small--md type-center line-caption line-copy--md pad-x-0 pad-x-lg--md pad-b-lg";
+					notes.style = "white-space:pre-line;";
 
-				//We add the notes to it (Note to self: stop repeating comments)
-				notes.textContent = datajson[0].notes;
+					//We add the notes to it (Note to self: stop repeating comments)
+					notes.textContent = datajson[0].notes;
 
-				//And now we add the notes container to the div, the div to the other div, etc
-				sonsson.appendChild(notes);
-				son.appendChild(sonsson);
-				document.getElementsByClassName("pos-r")[0].appendChild(son);
-			}
-		}) 
-		.catch(error => {
-			if (error instanceof TypeError)
-				console.log("[HOMESTUCK COMPANION] There is no commentary available for this page yet, but there may be in the future. Support the official book releases!");
-		}); //or if there's an error remove the container
+					//And now we add the notes container to the div, the div to the other div, etc
+					sonsson.appendChild(notes);
+					son.appendChild(sonsson);
+					document.getElementsByClassName("pos-r")[0].appendChild(son);
+				}
+			})
+			.catch(error => {
+				if (error instanceof TypeError)
+					console.log("[HOMESTUCK COMPANION] There is no commentary available for this page yet, but there may be in the future. Support the official book releases!");
+			}); //or if there's an error remove the container
+	}
 }
 
 //Keyboard controls
@@ -83,7 +85,7 @@ document.onkeydown = function(e) {
     	case 17: //either ctrl key
     		if(e.location == 2){ //restricts key to right ctrl
     			if(document.activeElement.id != "SBURBStage" && document.activeElement.type != "application/x-shockwave-flash") {
-            	document.getElementsByClassName("o_chat-log-btn")[0].click();
+            		document.getElementsByClassName("o_chat-log-btn")[0].click();
         		}
         	}
     		break;

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
         "*://www.homestuck.com/problem-sleuth", "*://www.homestuck.com/problem-sleuth/*",
         "*://www.homestuck.com/jailbreak", "*://www.homestuck.com/jailbreak/*",
         "*://www.homestuck.com/ryanquest", "*://www.homestuck.com/ryanquest/*",
+        "*://www.homestuck.com/epilogues", "*://www.homestuck.com/epilogues/*",
         "*://homestuck2.com/", "*://homestuck2.com/story", "*://homestuck2.com/story/*"
       ],
       "js": [

--- a/manifest.json
+++ b/manifest.json
@@ -18,8 +18,13 @@
 
   "content_scripts": [
     {
-      "matches": ["*://www.homestuck.com/problem-sleuth/*", "*://www.homestuck.com/story/*",
-      "*://www.homestuck.com/problem-sleuth", "*://www.homestuck.com/story"],
+      "matches": [
+        "*://www.homestuck.com/story","*://www.homestuck.com/story/*",
+        "*://www.homestuck.com/problem-sleuth", "*://www.homestuck.com/problem-sleuth/*",
+        "*://www.homestuck.com/jailbreak", "*://www.homestuck.com/jailbreak/*",
+        "*://www.homestuck.com/ryanquest", "*://www.homestuck.com/ryanquest/*",
+        "*://homestuck2.com/", "*://homestuck2.com/story", "*://homestuck2.com/story/*"
+      ],
       "js": [
         "node_modules/webextension-polyfill/dist/browser-polyfill.min.js",
         "hscompanion.js"
@@ -32,11 +37,9 @@
   },
 
   "permissions": [
-  "*://recordcrash.com/*",
-  "webRequest",
-  "storage"
+    "*://recordcrash.com/*",
+    "webRequest",
+    "storage"
   ]
-
-
 
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,4 @@
 {
-
   "description": "Adds commentary, keyboard navigation and useful info to the pages of Homestuck.com stories.",
   "manifest_version": 2,
   "name": "Homestuck Companion",
@@ -23,6 +22,7 @@
         "*://www.homestuck.com/problem-sleuth", "*://www.homestuck.com/problem-sleuth/*",
         "*://www.homestuck.com/jailbreak", "*://www.homestuck.com/jailbreak/*",
         "*://www.homestuck.com/ryanquest", "*://www.homestuck.com/ryanquest/*",
+        "*://www.homestuck.com/sweet-bro-and-hella-jeff", "*://www.homestuck.com/sweet-bro-and-hella-jeff/*",
         "*://www.homestuck.com/epilogues", "*://www.homestuck.com/epilogues/*",
         "*://homestuck2.com/", "*://homestuck2.com/story", "*://homestuck2.com/story/*"
       ],
@@ -42,5 +42,4 @@
     "webRequest",
     "storage"
   ]
-
 }


### PR DESCRIPTION
This closes issue #5. 

Navigation should now work on Jailbreak, Ryanquest, SBaHJ, the Epilogues, and Homestuck^2.

Tested on Firefox 70.0.1 and Chromium 78.0.39.